### PR TITLE
OAF helm chart dependency migrated to ph-ee-engine

### DIFF
--- a/helm/oaf/Chart.yaml
+++ b/helm/oaf/Chart.yaml
@@ -7,6 +7,6 @@ version: 0.1.0
 appVersion: 1.16.0
 
 dependencies:
-- name: ph-ee-engine-oaf
+- name: ph-ee-engine
   repository: https://fynarfin.io/images/
   version: 1.0.0-SNAPSHOT

--- a/helm/oaf/values.yaml
+++ b/helm/oaf/values.yaml
@@ -1,4 +1,4 @@
-ph-ee-engine-oaf:  
+ph-ee-engine:  
   zeebe:
     broker:
       contactpoint: "zeebe-zeebe-gateway:26500"
@@ -110,6 +110,15 @@ ph-ee-engine-oaf:
   operations:
     enabled: true
 
+  kafka:
+    enabled: true
+    image: "spotify/kafka"
+    advertised:
+      host: "kafka"
+      port: "9092"
+    deployment:
+      annotations: 
+        deployTime: "{{ .Values.deployTime }}"
 
   operationsmysql:
     fullnameOverride: "operationsmysql"
@@ -130,6 +139,7 @@ ph-ee-engine-oaf:
         GRANT ALL PRIVILEGES ON oaf.* TO 'mifos';
 
   channel:
+    enabled: true
     DFSPIDS: "oaf"
     transaction_id_length: 20
     SPRING_PROFILES_ACTIVE: "bb"
@@ -142,6 +152,11 @@ ph-ee-engine-oaf:
       annotations: 
         kubernetes.io/ingress.class: "kong"
         konghq.com/strip-path: "true"
+      backend:
+        service:
+          name: ph-ee-connector-channel
+          port:
+            number: 80
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -164,6 +179,11 @@ ph-ee-engine-oaf:
       annotations: 
         kubernetes.io/ingress.class: "kong"
         konghq.com/strip-path: "true"
+      backend:
+        service:
+          name: ph-ee-operations-app
+          port:
+            number: 80
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -179,6 +199,11 @@ ph-ee-engine-oaf:
       enabled: true
       annotations:
         kubernetes.io/ingress.class: "nginx"
+      backend:
+        service:
+          name: ph-ee-operations-web
+          port:
+            number: 4200
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -196,6 +221,7 @@ ph-ee-engine-oaf:
     SPRING_PROFILES_ACTIVE: "bb"
     hostname: "paymenthub.qa.oneacrefund.org"
     image: "oaftech.azurecr.io/phee-ns/ph-ee-connector-mpesa"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
     business_short_code: "668158"
     till_number: "9347335"
     callback_host: "https://paymenthub.qa.oneacrefund.org/mpesa"
@@ -213,6 +239,11 @@ ph-ee-engine-oaf:
       annotations: 
         kubernetes.io/ingress.class: "kong"
         konghq.com/strip-path: "true"
+      backend:
+        service:
+          name: ph-ee-connector-mpesa
+          port:
+            number: 80
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -239,6 +270,7 @@ ph-ee-engine-oaf:
     SPRING_PROFILES_ACTIVE: "bb"
     image: "oaftech.azurecr.io/phee-ns/ph-ee-notifications"
     hostname: "paymenthub.qa.oneacrefund.org"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
     MESSAGEGATEWAYCONFIG_HOST: "message-gateway"
     NOTIFICATION_LOCAL_HOST: "ph-ee-connector-notifications"
     NOTIFICATION_SUCCESS_ENABLED: "false"
@@ -248,6 +280,11 @@ ph-ee-engine-oaf:
       annotations: 
         kubernetes.io/ingress.class: "kong"
         konghq.com/strip-path: "true"
+      backend:
+        service:
+          name: ph-ee-connector-notifications
+          port:
+            number: 80
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -258,10 +295,16 @@ ph-ee-engine-oaf:
     enabled: true
     image: "oaftech.azurecr.io/phee-ns/phee-zeebe-ops"
     hostname: "paymenthub.qa.oneacrefund.org"
+    zeebe_broker_contactpoint: "zeebe-zeebe-gateway:26500"
     ingress:
       annotations: 
         kubernetes.io/ingress.class: "kong"
         konghq.com/strip-path: "true"
+      backend:
+        service:
+          name: ph-ee-zeebe-ops
+          port:
+            number: 80
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -287,6 +330,11 @@ ph-ee-engine-oaf:
       annotations: 
         kubernetes.io/ingress.class: "kong"
         konghq.com/strip-path: "true"
+      backend:
+        service:
+          name: message-gateway
+          port:
+            number: 80
     deployment:
       annotations:
         co.elastic.logs/enabled: "true"
@@ -296,6 +344,7 @@ ph-ee-engine-oaf:
     image: "oaftech.azurecr.io/phee-ns/ph-ee-importer-es"
 
   importer_rdbms:
+    enabled: true
     image: "oaftech.azurecr.io/phee-ns/ph-ee-importer-rdbms"
     LOGGING_LEVEL_ROOT: "INFO"
     datasource:


### PR DESCRIPTION
Below are the changes introduces after migrating from `ph-ee-engine-oaf` to `ph-ee-engine`
1. Backend block added for each ingress block.
2. Explicitly enable all the microservices we need in `QA` environment. (`enable: true`)
3. Added env variable value for`zeebe_broker_contactpoint` field, which was earlier not present as a parameter.
